### PR TITLE
Set default selenium version to 4.*.*-* and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SPECIAL THANKS
  * 2021 SrMilton ([miltonmanuelcramos@gmail.com](mailto:miltonmanuelcramos@gmail.com)), Mecanik ([Norbert.Boros@liveguard-software.com](mailto:Norbert.Boros@liveguard-software.com))
  * 2022 Mecanik ([Norbert.Boros@liveguard-software.com](mailto:Norbert.Boros@liveguard-software.com)), No-47 ([jacquessetsee34@gmail.com](mailto:jacquessetsee34@gmail.com))
  * 2024 Foxgoblin Xing ([foxgoblin@shockwest.com](mailto:foxgoblin@shockwest.com))
- * 2025 DanielAtCosmicDNA (Daniel Kaminski) ([daniel@cosmicdna.co.uk](mailto:daniel@cosmicdna.co.uk)), stas-badzi (Stanisław Badziak) ([stasbadzi@staszic.waw.pl](mailto:stasbadzi@staszic.waw.pl))
+ * 2025 DanielAtCosmicDNA (Daniel Kaminski) ([daniel@cosmicdna.co.uk](mailto:daniel@cosmicdna.co.uk))
 ## Cloning repository
 
 ```bash
@@ -49,7 +49,7 @@ sudo emerge -av dev-util/cmake sys-devel/gcc sys-devel/make net-misc/curl
 ## Compile on Linux, FreeBSD, OpenBSD
 ```bash
 mkdir build && cd build && cmake ..
-sudo make
+sudo make install
 ```
 
 ## Compile on Windows

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SPECIAL THANKS
  * 2021 SrMilton ([miltonmanuelcramos@gmail.com](mailto:miltonmanuelcramos@gmail.com)), Mecanik ([Norbert.Boros@liveguard-software.com](mailto:Norbert.Boros@liveguard-software.com))
  * 2022 Mecanik ([Norbert.Boros@liveguard-software.com](mailto:Norbert.Boros@liveguard-software.com)), No-47 ([jacquessetsee34@gmail.com](mailto:jacquessetsee34@gmail.com))
  * 2024 Foxgoblin Xing ([foxgoblin@shockwest.com](mailto:foxgoblin@shockwest.com))
- * 2025 DanielAtCosmicDNA (Daniel Kaminski) ([daniel@cosmicdna.co.uk](mailto:daniel@cosmicdna.co.uk))
+ * 2025 DanielAtCosmicDNA (Daniel Kaminski) ([daniel@cosmicdna.co.uk](mailto:daniel@cosmicdna.co.uk)), stas-badzi (Stanisław Badziak) ([stasbadzi@staszic.waw.pl](mailto:stasbadzi@staszic.waw.pl))
 ## Cloning repository
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -114,15 +114,20 @@ You need to download and run selenium-server-standalone.
 
 #### IMPORTANT NOTICE
 
-If you decide to use version selenium server version 4.0.0 and up (which is suggested), either compile with `-DSELENIUM_MAJOR=4`, or `#define SELENIUM_MAJOR 4` before including `webdriverxx.h`
-
-In some other versions you might need to initialize `WebDriver` objects with `http://localhost:4444/wd/hub` or any other url where your server is located suffixed with `/wd/hub`
+If you decide to use a selenium server version older than v4.0.0-alpha, either compile with `-DSELENIUM_MAJOR=3/2/1`, or `#define SELENIUM_MAJOR 3/2/1` before including `webdriverxx.h`
 
 #### Windows
 
 Download latest OpenJDK and unpack: https://openjdk.java.net/
 
-Official Selenium server can be seen here: https://selenium-release.storage.googleapis.com/index.html
+Official Selenium server can be seen here:
+- versions from 2.39 to 4.0.0-beta-4 https://selenium-release.storage.googleapis.com/index.html
+- versions from 4.0.0 to latest >= https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid
+
+Powershell
+```powershell
+Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid/4.37.0/selenium-grid-4.37.0.jar"
+```
 
 Set the path enviroment variable to OpenJDK or move to the OpenJDK folder
 
@@ -147,13 +152,15 @@ sudo pacman -Syu jre-openjdk jre-openjdk-headless
 sudo emerge -av virtual/jre
 ```
 
-Official Selenium server can be seen here: https://selenium-release.storage.googleapis.com/index.html
+Official Selenium server can be seen here:
+- versions from 2.39 to 4.0.0-beta-4 https://selenium-release.storage.googleapis.com/index.html
+- versions from 4.0.0 to latest >= https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid
 
 ```bash
-wget https://selenium-release.storage.googleapis.com/4.0-beta-4/selenium-server-4.0.0-beta-4.jar
+wget https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid/4.37.0/selenium-grid-4.37.0.jar
 ```
 
-or download from AUR [here](https://aur.archlinux.org/packages/selenium-server-standalone/):
+or download from AUR (not recomended - outdated version v3.141.59-1) [here](https://aur.archlinux.org/packages/selenium-server-standalone/):
 
 ```bash
 sudo yay -S --aur aur/selenium-server-standalone

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Webdriver++
 
 A C++ client library for [Selenium Webdriver](http://www.seleniumhq.org/).
@@ -122,11 +121,11 @@ Download latest OpenJDK and unpack: https://openjdk.java.net/
 
 Official Selenium server can be seen here:
 - versions from 2.39 to 4.0.0-beta-4 https://selenium-release.storage.googleapis.com/index.html
-- versions from 4.0.0 to latest >= https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid
+- all versions (scroll to the release that you want, click `Artifacts` and download `selenium-server-#.#.#.jar`) https://github.com/SeleniumHQ/selenium/releases
 
 Powershell
 ```powershell
-Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid/4.37.0/selenium-grid-4.37.0.jar"
+Invoke-WebRequest -Uri https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.36.0/selenium-server-4.36.0.jar
 ```
 
 Set the path enviroment variable to OpenJDK or move to the OpenJDK folder
@@ -154,10 +153,10 @@ sudo emerge -av virtual/jre
 
 Official Selenium server can be seen here:
 - versions from 2.39 to 4.0.0-beta-4 https://selenium-release.storage.googleapis.com/index.html
-- versions from 4.0.0 to latest >= https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid
+- all versions (scroll to the release that you want, click `Artifacts` and download `selenium-server-#.#.#.jar`) https://github.com/SeleniumHQ/selenium/releases
 
 ```bash
-wget https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-grid/4.37.0/selenium-grid-4.37.0.jar
+wget https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.36.0/selenium-server-4.36.0.jar
 ```
 
 or download from AUR (not recomended - outdated version v3.141.59-1) [here](https://aur.archlinux.org/packages/selenium-server-standalone/):

--- a/include/webdriverxx.h
+++ b/include/webdriverxx.h
@@ -1,6 +1,8 @@
 #ifndef WEBDRIVERXX_H
 #define WEBDRIVERXX_H
-
+#ifndef SELENIUM_MAJOR
+#define SELENIUM_MAJOR 4
+#endif
 #include "webdriverxx/webdriver.h"
 #include "webdriverxx/browsers/chrome.h"
 #include "webdriverxx/browsers/firefox.h"

--- a/include/webdriverxx/client.h
+++ b/include/webdriverxx/client.h
@@ -11,7 +11,11 @@
 
 namespace webdriverxx {
 
+#if SELENIUM_MAJOR >= 4
 const char *const kDefaultWebDriverUrl = "http://localhost:4444";
+#else
+const char *const kDefaultWebDriverUrl = "http://localhost:4444/wd/hub";
+#endif
 
 // Gives low level access to server's resources. You normally should not use it.
 class Client { // copyable


### PR DESCRIPTION
Since in the past in this repository there had been changes to support the latest (4.0.0+) protocol, the default selenium server version should probably be >=4.0.0 and not <=3.x.x so I changed that, and fixed a part of the 3.x.x compatibility (added "/wd/hub" suffix when compiling with `-DSELENIUM_MAJOR=3/2/1`), then modified the README to match it. I also fixed some problems with the README (`sudo make` -> `sudo make install` , added link to newer selenium versions, added AUR old version notice)